### PR TITLE
Remove unnecessary check for blamable columns

### DIFF
--- a/src/Traits/Blameable.php
+++ b/src/Traits/Blameable.php
@@ -13,8 +13,6 @@ trait Blameable
 
     public static function bootBlameable()
     {
-        static::checkBlameableColumns();
-
         static::creating(function ($model) {
             $createdByAttribute = Config::get('blameable.column_names.createdByAttribute', 'created_by');
             $model->$createdByAttribute = Auth::id();
@@ -31,18 +29,6 @@ trait Blameable
                 $model->$deletedByAttribute = Auth::id();
                 $model->save();
             });
-        }
-    }
-
-    public static function checkBlameableColumns() {
-        $table = (new static)->getTable();
-        $createdByAttribute = Config::get('blameable.column_names.createdByAttribute', 'created_by');
-        $updatedByAttribute = Config::get('blameable.column_names.updatedByAttribute', 'updated_by');
-        $deletedByAttribute = Config::get('blameable.column_names.deletedByAttribute', 'deleted_by');
-        if (!Schema::hasColumn($table, $createdByAttribute)
-            && !Schema::hasColumn($table, $updatedByAttribute)
-            && !Schema::hasColumn($table, $deletedByAttribute)) {
-            //
         }
     }
 


### PR DESCRIPTION
First of all: Thank you for this package!
We had an issue in CI that caused our build to fail after the introduction of your package. While investigating, I realised that the `Blamable` trait checks in the boot of the attached Model for the columns. Strangely, this condition is empty (https://github.com/DigitalCloud/laravel-blameable/pull/5/files#diff-d6705a3dd38ef920c15075fae0f8ceb9L45) , so I went ahead and removed the whole check. 

Would be cool, if we could get this merged and tagged 😄  
Again: Thank you for your work!
