### PR TITLE
Update blameable.php

### DIFF
--- a/config/blameable.php
+++ b/config/blameable.php
@@ -7,6 +7,6 @@ return [
         'deletedByAttribute' => 'deleted_by',
     ],
     'models' => [
-        'user' => \App\User::class
+        'user' => \App\Models\User::class
     ]
 ];


### PR DESCRIPTION
Laravel updated the default namespace for Models. We should aim to be consistent with new versions of Laravel.